### PR TITLE
chore: bump django version for security vuln

### DIFF
--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via edx-django-utils
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   django-crum

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,7 +87,7 @@ distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -47,7 +47,7 @@ cryptography==37.0.4
     # via secretstorage
 ddt==1.5.0
     # via -r requirements/test.txt
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -54,7 +54,7 @@ ddt==1.5.0
     # via -r requirements/test.txt
 dill==0.3.5.1
     # via pylint
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ coverage[toml]==6.4.2
     # via pytest-cov
 ddt==1.5.0
     # via -r requirements/test.in
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt


### PR DESCRIPTION
To resolve dependable alert https://github.com/advisories/GHSA-8x94-hmjh-97hq.
