### PR TITLE
feat: support passing enterprise_customer_uuid for allocation payload

### DIFF
--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.1'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -45,7 +45,8 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         country_code=None,
         mobile_phone=None,
         work_experience=None,
-        education_highest_level=None
+        education_highest_level=None,
+        enterprise_customer_uuid=None
     ):
         """
         Create an allocation (enrollment) through GEAG.
@@ -77,22 +78,25 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             'Bachelor’s degree', 'Master’s degree', 'Doctoral degree',
             'Other tertiary qualification', 'Honours degree',
             'Bachelors degree']
+          - `enterprise_customer_uuid (str)`: UUID of the enterprise
+             that sponsored this allocation
 
         **Example payload**
-          { "paymentReference": "GS-12304",
-            "firstName": "Jan",
-            "lastName": "Pan",
-            "email": "janpan@gs.com",
-            "dateOfBirth": "2021-05-12",
-            "termsAcceptedAt": "2021-05-21T17:32:28Z",
-            "currency": "ZAR",
-            "orderItems": [{ "productId": "product_id", "quantity": 1,
-            "normalPrice": 1000, "discount": 500, "finalPrice": 500 }],
-            "addressLine1": "Oak Glen",
-            "city": "Cape Town",
-            "postalCode": "7570",
-            "country": "South Africa",
-            "countryCode": "ZA" }
+         { "paymentReference": "GS-12304",
+           "firstName": "Jan",
+           "lastName": "Pan",
+           "email": "janpan@gs.com",
+           "dateOfBirth": "2021-05-12",
+           "termsAcceptedAt": "2021-05-21T17:32:28Z",
+           "currency": "ZAR",
+           "orderItems": [{ "productId": "product_id", "quantity": 1,
+           "normalPrice": 1000, "discount": 500, "finalPrice": 500 }],
+           "addressLine1": "Oak Glen",
+           "city": "Cape Town",
+           "postalCode": "7570",
+           "country": "South Africa",
+           "countryCode": "ZA",
+           "enterprise_customer_uuid": "731b28ee-09d1-4b89-8f7b-2c8fd0939746" }
 
         """
         url = f'{self.api_url}/allocations'
@@ -118,6 +122,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             'mobilePhone': mobile_phone,
             'workExperience': work_experience,
             'educationHighestLevel': education_highest_level,
+            'enterprise_customer_uuid': enterprise_customer_uuid
         }
         # remove keys with empty values
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/tests/getsmarter_api_clients/test_geag.py
+++ b/tests/getsmarter_api_clients/test_geag.py
@@ -96,7 +96,8 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'country': 'country',
             'country_code': 'country_code',
             'mobile_phone': '+12015551234',
-            'work_experience': 'None'
+            'work_experience': 'None',
+            'enterprise_customer_uuid': '731b28ee-09d1-4b89-8f7b-2c8fd0939746'
         }
         client.create_allocation(**kwargs)
 
@@ -117,7 +118,8 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'country': kwargs['country'],
             'countryCode': kwargs['country_code'],
             'mobilePhone': kwargs['mobile_phone'],
-            'workExperience': kwargs['work_experience']
+            'workExperience': kwargs['work_experience'],
+            'enterprise_customer_uuid': kwargs['enterprise_customer_uuid']
         }
 
         self.assertEqual(len(responses.calls), 1)


### PR DESCRIPTION
GetSmarter will add an enterprise_customer_uuid field to the allocation endpoint. This change will support that update.

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
