### PR TITLE
feat: Added data sharing field for enterprise allocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[0.5.0] - 2023-04-12
+~~~~~~~~~~~~~~~~~~~~
+
+* Added new field for data_share_consent in enterprise_allocations
+
 [0.4.0] - 2022-09-12
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -155,6 +155,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         email,
         date_of_birth,
         terms_accepted_at,
+        data_share_consent,
         currency,
         order_items,
         address_line1=None,
@@ -183,6 +184,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
           - `date_of_birth (str)`: Date of birth
           - `terms_accepted_at (str)`: ISO 8601 timestamp of
             when the terms and policies were accepted
+          - `data_share_consent (bool)`: Learner consent for data sharing
           - `currency (str)`: One of ['USD', 'GBP', 'ZAR', 'EUR', 'AED',
             'SGD', 'HKD', 'SAR', 'INR', 'CAD']
           - `order_items (list of dict)`: Items ordered
@@ -230,6 +232,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             'email': email,
             'dateOfBirth': date_of_birth,
             'termsAcceptedAt': terms_accepted_at,
+            'dataShareConsent': data_share_consent,
             'currency': currency,
             'orderItems': order_items,
             # optional fields

--- a/tests/getsmarter_api_clients/test_geag.py
+++ b/tests/getsmarter_api_clients/test_geag.py
@@ -142,6 +142,7 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'email': 'johnsmith@example.com',
             'date_of_birth': '2000-01-01',
             'terms_accepted_at': '2022-07-25T10:29:56Z',
+            'data_share_consent': 'true',
             'currency': 'USD',
             'order_items': [
                 {
@@ -173,6 +174,7 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'email': kwargs['email'],
             'dateOfBirth': kwargs['date_of_birth'],
             'termsAcceptedAt': kwargs['terms_accepted_at'],
+            'dataShareConsent': kwargs['data_share_consent'],
             'currency': kwargs['currency'],
             'orderItems': kwargs['order_items'],
             'addressLine1': kwargs['address_line1'],


### PR DESCRIPTION
**Description:** This PR adds a new field "dataShareConsent" to the enterprise allocation payload

**JIRA:** [ENT-6794](https://2u-internal.atlassian.net/browse/ENT-6794)

**Reviewers:**
- [x] tag reviewer 
- [x] tag reviewer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

