### PR TITLE
feat: include enterprise orgId in allocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.5.4]
+~~~~~~~
+* Add `org_id`` as an optional enterprise allocation param
+
 [0.5.3]
 ~~~~~~~
 * Return allocation response objects

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -171,7 +171,8 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         country_code=None,
         mobile_phone=None,
         work_experience=None,
-        education_highest_level=None
+        education_highest_level=None,
+        org_id=None
     ):
         """
         Create an enterprise_allocation (enrollment) through GEAG.
@@ -206,6 +207,8 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             'Bachelor’s degree', 'Master’s degree', 'Doctoral degree',
             'Other tertiary qualification', 'Honours degree',
             'Bachelors degree']
+          - `org_id (str)`: `auth_org_id` from the learner’s
+            `EnterpriseCustomer` record
 
         **Example payload**
           { "paymentReference": "GS-12304",
@@ -222,7 +225,8 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             "city": "Cape Town",
             "postalCode": "7570",
             "country": "South Africa",
-            "countryCode": "ZA" }
+            "countryCode": "ZA",
+            "orgId": "12KJ2j9js0" }
 
         """
         url = f'{self.api_url}/enterprise_allocations'
@@ -250,6 +254,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             'mobilePhone': mobile_phone,
             'workExperience': work_experience,
             'educationHighestLevel': education_highest_level,
+            'orgId': org_id,
         }
         # remove keys with empty values
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/tests/getsmarter_api_clients/test_geag.py
+++ b/tests/getsmarter_api_clients/test_geag.py
@@ -162,7 +162,8 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'country': 'country',
             'country_code': 'country_code',
             'mobile_phone': '+12015551234',
-            'work_experience': 'None'
+            'work_experience': 'None',
+            'org_id': '12KJ2j9js0',
         }
         client.create_enterprise_allocation(**kwargs)
 
@@ -185,7 +186,8 @@ class GetSmarterEnterpriseApiClientTests(BaseOAuthApiClientTests):
             'country': kwargs['country'],
             'countryCode': kwargs['country_code'],
             'mobilePhone': kwargs['mobile_phone'],
-            'workExperience': kwargs['work_experience']
+            'workExperience': kwargs['work_experience'],
+            'orgId': kwargs['org_id'],
         }
 
         self.assertEqual(len(responses.calls), 1)


### PR DESCRIPTION
**Description:** Describe in a couple of sentences what this PR adds

- allow enterprise allocation calls to pass in an `org_id` for inclusion in the payload
- https://2u-internal.atlassian.net/browse/ENT-7079

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
