### PR TITLE
feat: geag allocation call optionally returns error response. ENT-7271

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Nothing unreleased
 
-*
+[0.6.0]
+~~~~~~~
+* Adds optional arg to create_enterprise_allocation() to either raise (current/default behavior),
+  or not raise and fall through to returning the response. This will allow callers
+  to do things with the response payload in error conditions.
 
 [0.5.4]
 ~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ quality: ## check coding style with pycodestyle and pylint
 	twine check dist/*
 	make selfcheck
 
+isort:
+	isort --diff --recursive tests test_utils getsmarter_api_clients *.py test_settings.py
+
+pylint:
+	pylint getsmarter_api_clients tests test_utils *.py
+
+style:
+	pycodestyle getsmarter_api_clients tests  *.py
 
 requirements: ## install development environment requirements
 	pip install -r requirements/pip.txt

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.5.4'
+__version__ = '0.6.0'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -172,7 +172,8 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         mobile_phone=None,
         work_experience=None,
         education_highest_level=None,
-        org_id=None
+        org_id=None,
+        should_raise=True,
     ):
         """
         Create an enterprise_allocation (enrollment) through GEAG.
@@ -269,5 +270,6 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
               f'with payload: {payload}'
             )
             logger.error(message)
-            raise
+            if should_raise:
+                raise
         return response

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ multi_line_output = 3
 
 [wheel]
 universal = 1
+
+[flake8]
+max-line-length=120


### PR DESCRIPTION
**Description:**
Adds optional arg to `create_enterprise_allocation()` to either raise (current/default behavior), or not raise and fall through to returning the response.  This will allow callers to do things with the response payload in error conditions.
1st step of https://2u-internal.atlassian.net/browse/ENT-7271

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
