### PR TITLE
feat: add enterprise allocation cancellation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 * Nothing unreleased
 
+[0.6.1]
+~~~~~~~
+* Adds an enterprise allocation cancellation method
+
 [0.6.0]
 ~~~~~~~
 * Adds optional arg to create_enterprise_allocation() to either raise (current/default behavior),

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -273,3 +273,35 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
             if should_raise:
                 raise
         return response
+
+    def cancel_enterprise_allocation(
+        self,
+        order_uuid,
+        should_raise=True,
+    ):
+        """
+        Cancel an enterprise_allocation (enrollment) through GEAG.
+
+        :Parameters:
+          - `order_uuid` (str): The order UUID of the allocation
+          - `should_raise` (boolean): Should exceptions be re-raised
+        """
+        url = f'{self.api_url}/enterprise_allocations/cancel'
+
+        payload = {
+            'orderUuid': str(order_uuid),
+        }
+
+        response = self.post(url, json=payload)
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            message = (
+              f'Allocation cancelation failed for {order_uuid} '
+              f'with reasons: {response.text}, '
+              f'with payload: {payload}'
+            )
+            logger.error(message)
+            if should_raise:
+                raise
+        return response


### PR DESCRIPTION
## Description

- add enterprise allocation cancellation to client
- tests
- version bump
- https://2u-internal.atlassian.net/browse/ENT-7325