### PR TITLE
fix: log the GEAG allocation payload & upgrade requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 * Nothing unreleased
+
+[0.6.2]
+~~~~~~~
+* Logs the allocation payload sent to GEAG within the ``create_allocation`` method.
 
 [0.6.1]
 ~~~~~~~

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -132,6 +132,14 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         # remove keys with empty values
         payload = {k: v for k, v in payload.items() if v is not None}
 
+        # log the payload
+        payload_message = (
+            f'Attempting allocation for order {payment_reference} '
+            f'with payload: {payload}'
+        )
+        logger.info(payload_message)
+
+        # send the allocation
         response = self.post(url, json=payload)
         try:
             response.raise_for_status()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,15 +6,15 @@
 #
 asgiref==3.8.1
     # via django
-certifi==2024.8.30
+certifi==2025.4.26
     # via requests
 cffi==1.17.1
     # via pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via requests
-click==8.1.7
+click==8.1.8
     # via edx-django-utils
-django==4.2.16
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   django-crum
@@ -22,35 +22,40 @@ django==4.2.16
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.2.0
     # via edx-django-utils
-edx-django-utils==7.0.0
+edx-django-utils==7.4.0
     # via -r requirements/base.in
 idna==3.10
     # via requests
-newrelic==10.2.0
+newrelic==10.11.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
     #   -r requirements/base.in
     #   requests-oauthlib
-pbr==6.1.0
+pbr==6.1.1
     # via stevedore
-psutil==6.1.0
+psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
 pynacl==1.5.0
     # via edx-django-utils
-pytz==2024.2
+pytz==2025.2
     # via -r requirements/base.in
 requests==2.32.3
     # via requests-oauthlib
 requests-oauthlib==2.0.0
     # via -r requirements/base.in
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via django
-stevedore==5.3.0
+stevedore==5.4.1
     # via edx-django-utils
 urllib3==2.2.3
-    # via requests
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.0
+cachetools==5.5.2
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,23 +12,23 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.16.1
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-packaging==24.1
+packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via tox
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via tox
-tox==4.23.2
+tox==4.25.0
     # via -r requirements/ci.in
-virtualenv==20.27.1
+virtualenv==20.31.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,42 +6,42 @@
 #
 asgiref==3.8.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   django
 astroid==3.3.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
 build==1.2.2.post1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 cachetools==5.5.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 certifi==2025.4.26
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   diff-cover
     #   tox
 charset-normalizer==3.4.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
 click==8.1.8
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -49,135 +49,135 @@ click==8.1.8
     #   pip-tools
 click-log==0.4.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 colorama==0.4.6
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 coverage[toml]==7.8.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 diff-cover==9.2.4
     # via -r requirements/dev.in
 dill==0.4.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 distlib==0.3.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   virtualenv
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-django-utils
 django-waffle==4.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-django-utils
 docutils==0.21.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   readme-renderer
 edx-django-utils==7.4.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 edx-lint==5.6.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 filelock==3.18.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 id==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 idna==3.10
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
 iniconfig==2.1.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 jaraco-classes==3.4.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 jaraco-functools==4.1.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 jinja2==3.1.6
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
 keyring==25.6.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 markdown-it-py==3.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   rich
 markupsafe==3.0.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   jinja2
 mccabe==0.7.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   markdown-it-py
 more-itertools==10.7.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
 newrelic==10.11.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-django-utils
 nh3==0.2.21
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests-oauthlib
 packaging==25.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
     #   build
     #   pyproject-api
     #   pytest
@@ -185,163 +185,163 @@ packaging==25.0
     #   twine
 pbr==6.1.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   stevedore
 pip-tools==7.4.1
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    # via -r requirements/pip-tools.txt
 platformdirs==4.3.7
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   diff-cover
     #   pytest
     #   tox
 psutil==7.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-django-utils
 pycodestyle==2.13.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 pycparser==2.22
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   cffi
 pydocstyle==6.3.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 pygments==2.19.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   diff-cover
     #   readme-renderer
     #   rich
 pylint==3.3.7
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 pylint-plugin-utils==0.8.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
 pynacl==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-django-utils
 pyproject-api==1.9.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
 pytest==8.3.5
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-cov
 pytest-cov==6.1.1
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 python-slugify==8.0.4
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
 pytz==2025.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 pyyaml==6.0.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
     #   responses
 readme-renderer==44.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 requests==2.32.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   id
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   twine
 requests-oauthlib==2.0.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 requests-toolbelt==1.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 responses==0.25.7
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 rfc3986==2.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 rich==14.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 six==1.17.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 snowballstemmer==2.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pydocstyle
 sqlparse==0.5.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   python-slugify
 tomlkit==0.13.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 tox==4.25.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    # via -r requirements/ci.txt
 twine==6.1.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    # via -r requirements/quality.txt
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
     #   responses
     #   twine
 virtualenv==20.31.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 wheel==0.45.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,42 +6,42 @@
 #
 asgiref==3.8.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   django
-astroid==3.3.5
+astroid==3.3.9
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
     #   pylint-celery
 build==1.2.2.post1
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.5.0
+cachetools==5.5.2
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   tox
-certifi==2024.8.30
+certifi==2025.4.26
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   diff-cover
     #   tox
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -49,305 +49,300 @@ click==8.1.7
     #   pip-tools
 click-log==0.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
-code-annotations==1.8.0
+code-annotations==2.3.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
 colorama==0.4.6
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   tox
-coverage[toml]==7.6.4
+coverage[toml]==7.8.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r requirements/quality.txt
-diff-cover==9.2.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+diff-cover==9.2.4
     # via -r requirements/dev.in
-dill==0.3.9
+dill==0.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
 distlib==0.3.9
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   virtualenv
-django==4.2.16
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.2.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-django-utils
 docutils==0.21.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   readme-renderer
-edx-django-utils==7.0.0
-    # via -r requirements/quality.txt
-edx-lint==5.4.1
-    # via -r requirements/quality.txt
-filelock==3.16.1
+edx-django-utils==7.4.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+edx-lint==5.6.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+filelock==3.18.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   tox
     #   virtualenv
+id==1.5.0
+    # via
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   twine
 idna==3.10
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   requests
-importlib-metadata==8.5.0
+iniconfig==2.1.0
     # via
-    #   -r requirements/quality.txt
-    #   twine
-iniconfig==2.0.0
-    # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pytest
-isort==5.13.2
+isort==6.0.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
 jaraco-classes==3.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   keyring
 jaraco-functools==4.1.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   keyring
-jinja2==3.1.4
+jinja2==3.1.6
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==25.5.0
+keyring==25.6.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   twine
 markdown-it-py==3.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   rich
 markupsafe==3.0.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   jinja2
 mccabe==0.7.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.7.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.2.0
+newrelic==10.11.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-django-utils
-nh3==0.2.18
+nh3==0.2.21
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   requests-oauthlib
-packaging==24.1
+packaging==25.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   build
     #   pyproject-api
     #   pytest
     #   tox
-pbr==6.1.0
+    #   twine
+pbr==6.1.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   stevedore
 pip-tools==7.4.1
-    # via -r requirements/pip-tools.txt
-pkginfo==1.10.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
+platformdirs==4.3.7
     # via
-    #   -r requirements/quality.txt
-    #   twine
-platformdirs==4.3.6
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   diff-cover
     #   pytest
     #   tox
-psutil==6.1.0
+psutil==7.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-django-utils
-pycodestyle==2.12.1
-    # via -r requirements/quality.txt
+pycodestyle==2.13.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 pycparser==2.22
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   cffi
 pydocstyle==6.3.0
-    # via -r requirements/quality.txt
-pygments==2.18.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+pygments==2.19.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==3.3.1
+pylint==3.3.7
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
 pylint-plugin-utils==0.8.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint-celery
     #   pylint-django
 pynacl==1.5.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-django-utils
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.3.3
+pytest==8.3.5
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pytest-cov
-pytest-cov==6.0.0
-    # via -r requirements/quality.txt
+pytest-cov==6.1.1
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 python-slugify==8.0.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   code-annotations
-pytz==2024.2
-    # via -r requirements/quality.txt
+pytz==2025.2
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 pyyaml==6.0.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   code-annotations
     #   responses
 readme-renderer==44.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   twine
 requests==2.32.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
+    #   id
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   twine
 requests-oauthlib==2.0.0
-    # via -r requirements/quality.txt
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 requests-toolbelt==1.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   twine
-responses==0.25.3
-    # via -r requirements/quality.txt
+responses==0.25.7
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 rfc3986==2.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   twine
-rich==13.9.4
+rich==14.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   twine
-six==1.16.0
+six==1.17.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   edx-lint
 snowballstemmer==2.2.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pydocstyle
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   django
-stevedore==5.3.0
+stevedore==5.4.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   python-slugify
 tomlkit==0.13.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   pylint
-tox==4.23.2
-    # via -r requirements/ci.txt
-twine==5.1.1
-    # via -r requirements/quality.txt
+tox==4.25.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
+twine==6.1.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
 urllib3==2.2.3
     # via
-    #   -r requirements/quality.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/quality.txt
     #   requests
     #   responses
     #   twine
-virtualenv==20.27.1
+virtualenv==20.31.1
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/ci.txt
     #   tox
-wheel==0.44.0
+wheel==0.45.1
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/pip-tools.txt
     #   pip-tools
-zipp==3.20.2
-    # via
-    #   -r requirements/quality.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,52 +10,52 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django
-babel==2.16.0
+babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
 build==1.2.2.post1
     # via -r requirements/doc.in
-certifi==2024.8.30
+certifi==2025.4.26
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-coverage[toml]==7.6.4
+coverage[toml]==7.8.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r requirements/test.txt
-django==4.2.16
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.2.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
 doc8==1.1.2
     # via -r requirements/doc.in
@@ -66,19 +66,19 @@ docutils==0.21.2
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-django-utils==7.0.0
-    # via -r requirements/test.txt
+edx-django-utils==7.4.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+id==1.5.0
+    # via twine
 idna==3.10
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0
-    # via twine
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest
 jaraco-classes==3.4.0
     # via keyring
@@ -86,9 +86,9 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.4
+jinja2==3.1.6
     # via sphinx
-keyring==25.5.0
+keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -96,47 +96,47 @@ markupsafe==3.0.2
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.2.0
+newrelic==10.11.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-nh3==0.2.18
+nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests-oauthlib
-packaging==24.1
+packaging==25.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   build
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pbr==6.1.0
+    #   twine
+pbr==6.1.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   stevedore
-pkginfo==1.10.0
-    # via twine
 pluggy==1.5.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest
-psutil==6.1.0
+psutil==7.0.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.16.0
+pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   accessible-pygments
     #   doc8
@@ -146,54 +146,57 @@ pygments==2.18.0
     #   sphinx
 pynacl==1.5.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
 pyproject-hooks==1.2.0
     # via build
-pytest==8.3.3
+pytest==8.3.5
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest-cov
-pytest-cov==6.0.0
-    # via -r requirements/test.txt
-pytz==2024.2
-    # via -r requirements/test.txt
+pytest-cov==6.1.1
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+pytz==2025.2
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 pyyaml==6.0.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   responses
 readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   id
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   sphinx
     #   twine
 requests-oauthlib==2.0.0
-    # via -r requirements/test.txt
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 requests-toolbelt==1.0.0
     # via twine
-responses==0.25.3
-    # via -r requirements/test.txt
+responses==0.25.7
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.9.4
+rich==14.0.0
     # via twine
+roman-numerals-py==3.1.0
+    # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.3
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.3
+sphinx-book-theme==1.1.4
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -207,24 +210,28 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django
-stevedore==5.3.0
+stevedore==5.4.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   doc8
     #   edx-django-utils
-twine==5.1.1
+twine==6.1.0
     # via -r requirements/doc.in
-typing-extensions==4.12.2
-    # via pydata-sphinx-theme
+typing-extensions==4.13.2
+    # via
+    #   beautifulsoup4
+    #   pydata-sphinx-theme
 urllib3==2.2.3
     # via
-    #   -r requirements/test.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
     #   responses
     #   twine
-zipp==3.20.2
-    # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 babel==2.17.0
     # via
@@ -22,40 +22,40 @@ build==1.2.2.post1
     # via -r requirements/doc.in
 certifi==2025.4.26
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pynacl
 charset-normalizer==3.4.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.1.8
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 coverage[toml]==7.8.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 django-waffle==4.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 doc8==1.1.2
     # via -r requirements/doc.in
@@ -67,18 +67,18 @@ docutils==0.21.2
     #   restructuredtext-lint
     #   sphinx
 edx-django-utils==7.4.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 id==1.5.0
     # via twine
 idna==3.10
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
 iniconfig==2.1.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 jaraco-classes==3.4.0
     # via keyring
@@ -102,17 +102,17 @@ more-itertools==10.7.0
     #   jaraco-functools
 newrelic==10.11.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
 packaging==25.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   build
     #   pydata-sphinx-theme
     #   pytest
@@ -120,19 +120,19 @@ packaging==25.0
     #   twine
 pbr==6.1.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   stevedore
 pluggy==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 psutil==7.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
@@ -146,27 +146,27 @@ pygments==2.19.1
     #   sphinx
 pynacl==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-hooks==1.2.0
     # via build
 pytest==8.3.5
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==6.1.1
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 pytz==2025.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 pyyaml==6.0.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   responses
 readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   id
     #   requests-oauthlib
     #   requests-toolbelt
@@ -174,11 +174,11 @@ requests==2.32.3
     #   sphinx
     #   twine
 requests-oauthlib==2.0.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 requests-toolbelt==1.0.0
     # via twine
 responses==0.25.7
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
@@ -212,11 +212,11 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlparse==0.5.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   doc8
     #   edx-django-utils
 twine==6.1.0
@@ -228,7 +228,7 @@ typing-extensions==4.13.2
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,9 +6,9 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.1.7
+click==8.1.8
     # via pip-tools
-packaging==24.1
+packaging==25.0
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
@@ -16,7 +16,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.44.0
+wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.3.1
+pip==25.1.1
     # via -r requirements/pip.in
-setuptools==75.3.0
+setuptools==80.3.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.8.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 astroid==3.3.9
     # via
@@ -14,19 +14,19 @@ astroid==3.3.9
     #   pylint-celery
 certifi==2025.4.26
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pynacl
 charset-normalizer==3.4.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.1.8
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -37,42 +37,42 @@ code-annotations==2.3.0
     # via edx-lint
 coverage[toml]==7.8.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 dill==0.4.0
     # via pylint
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 django-waffle==4.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 docutils==0.21.2
     # via readme-renderer
 edx-django-utils==7.4.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 edx-lint==5.6.0
     # via -r requirements/quality.in
 id==1.5.0
     # via twine
 idna==3.10
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 iniconfig==2.1.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
@@ -102,38 +102,38 @@ more-itertools==10.7.0
     #   jaraco-functools
 newrelic==10.11.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
 packaging==25.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
     #   twine
 pbr==6.1.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   stevedore
 platformdirs==4.3.7
     # via pylint
 pluggy==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 psutil==7.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pycodestyle==2.13.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
@@ -157,39 +157,39 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pynacl==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pytest==8.3.5
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==6.1.1
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 python-slugify==8.0.4
     # via code-annotations
 pytz==2025.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 pyyaml==6.0.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   responses
 readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   id
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   twine
 requests-oauthlib==2.0.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 requests-toolbelt==1.0.0
     # via twine
 responses==0.25.7
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
 rich==14.0.0
@@ -200,11 +200,11 @@ snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.5.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
@@ -216,7 +216,7 @@ twine==6.1.0
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,75 +6,75 @@
 #
 asgiref==3.8.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django
-astroid==3.3.5
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
-certifi==2024.8.30
+certifi==2025.4.26
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.8.0
+code-annotations==2.3.0
     # via edx-lint
-coverage[toml]==7.6.4
+coverage[toml]==7.8.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
-    # via -r requirements/test.txt
-dill==0.3.9
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+dill==0.4.0
     # via pylint
-django==4.2.16
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.2.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
 docutils==0.21.2
     # via readme-renderer
-edx-django-utils==7.0.0
-    # via -r requirements/test.txt
-edx-lint==5.4.1
+edx-django-utils==7.4.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+edx-lint==5.6.0
     # via -r requirements/quality.in
+id==1.5.0
+    # via twine
 idna==3.10
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
-importlib-metadata==8.5.0
-    # via twine
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest
-isort==5.13.2
+isort==6.0.1
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -84,9 +84,9 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.4
+jinja2==3.1.6
     # via code-annotations
-keyring==25.5.0
+keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -96,53 +96,52 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.2.0
+newrelic==10.11.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-nh3==0.2.18
+nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests-oauthlib
-packaging==24.1
+packaging==25.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest
-pbr==6.1.0
+    #   twine
+pbr==6.1.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   stevedore
-pkginfo==1.10.0
-    # via twine
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via pylint
 pluggy==1.5.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest
-psutil==6.1.0
+psutil==7.0.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
-pylint==3.3.1
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -158,66 +157,69 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pynacl==1.5.0
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   edx-django-utils
-pytest==8.3.3
+pytest==8.3.5
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   pytest-cov
-pytest-cov==6.0.0
-    # via -r requirements/test.txt
+pytest-cov==6.1.1
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 python-slugify==8.0.4
     # via code-annotations
-pytz==2024.2
-    # via -r requirements/test.txt
+pytz==2025.2
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 pyyaml==6.0.2
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   code-annotations
     #   responses
 readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
+    #   id
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   twine
 requests-oauthlib==2.0.0
-    # via -r requirements/test.txt
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 requests-toolbelt==1.0.0
     # via twine
-responses==0.25.3
-    # via -r requirements/test.txt
+responses==0.25.7
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
 rfc3986==2.0.0
     # via twine
-rich==13.9.4
+rich==14.0.0
     # via twine
-six==1.16.0
+six==1.17.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   django
-stevedore==5.3.0
+stevedore==5.4.1
     # via
-    #   -r requirements/test.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
     # via python-slugify
 tomlkit==0.13.2
     # via pylint
-twine==5.1.1
+twine==6.1.0
     # via -r requirements/quality.in
 urllib3==2.2.3
     # via
-    #   -r requirements/test.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/test.txt
     #   requests
     #   responses
     #   twine
-zipp==3.20.2
-    # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,106 +6,110 @@
 #
 asgiref==3.8.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   django
-certifi==2024.8.30
+certifi==2025.4.26
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
-coverage[toml]==7.6.4
+coverage[toml]==7.8.0
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
-django==4.2.16
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.2.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
-edx-django-utils==7.0.0
-    # via -r requirements/base.txt
+edx-django-utils==7.4.0
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
 idna==3.10
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-newrelic==10.2.0
+newrelic==10.11.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
 oauthlib==3.2.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests-oauthlib
-packaging==24.1
+packaging==25.0
     # via pytest
-pbr==6.1.0
+pbr==6.1.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   stevedore
 pluggy==1.5.0
     # via pytest
-psutil==6.1.0
+psutil==7.0.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   cffi
 pynacl==1.5.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
-pytest==8.3.3
+pytest==8.3.5
     # via pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r requirements/test.in
-pytz==2024.2
-    # via -r requirements/base.txt
+pytz==2025.2
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
 pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests-oauthlib
     #   responses
 requests-oauthlib==2.0.0
-    # via -r requirements/base.txt
-responses==0.25.3
+    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+responses==0.25.7
     # via -r requirements/test.in
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   django
-stevedore==5.3.0
+stevedore==5.4.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   edx-django-utils
 urllib3==2.2.3
     # via
-    #   -r requirements/base.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
     #   requests
     #   responses
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,23 +6,23 @@
 #
 asgiref==3.8.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
 certifi==2025.4.26
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   pynacl
 charset-normalizer==3.4.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 click==8.1.8
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 coverage[toml]==7.8.0
     # via pytest-cov
@@ -31,83 +31,83 @@ ddt==1.7.2
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 django-waffle==4.2.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 edx-django-utils==7.4.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    # via -r requirements/base.txt
 idna==3.10
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 iniconfig==2.1.0
     # via pytest
 newrelic==10.11.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 oauthlib==3.2.2
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests-oauthlib
 packaging==25.0
     # via pytest
 pbr==6.1.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   stevedore
 pluggy==1.5.0
     # via pytest
 psutil==7.0.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   cffi
 pynacl==1.5.0
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 pytest==8.3.5
     # via pytest-cov
 pytest-cov==6.1.1
     # via -r requirements/test.in
 pytz==2025.2
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    # via -r requirements/base.txt
 pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests-oauthlib
     #   responses
 requests-oauthlib==2.0.0
-    # via -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    # via -r requirements/base.txt
 responses==0.25.7
     # via -r requirements/test.in
 sqlparse==0.5.3
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r /Users/astankiewicz/Desktop/edx/getsmarter-api-clients/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
     #   responses
 


### PR DESCRIPTION
**Description:** 

1. While debugging a customer issue, it was noted that we don't seem to log the actual payload we send to GEAG when creating an allocation. This lack of logging makes it difficult to understand confidently which `variant_id` our edX systems are passing to GEAG, contributing to more difficult debugging of production edge cases (e.g., did we send the expected `variant_id` to GEAG?).
2. Upgrades requirements with `make upgrade` (CI failing on `make quality` otherwise).

**JIRA:** [ENT-10386](https://2u-internal.atlassian.net/browse/ENT-10386)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Create an allocation.
3. Observe additional logging of the allocation payload sent to GEAG.


**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
