### PR TITLE
fix: use ubuntu-latest in pypi-publish GH action workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install pip
         run: pip install -r requirements/pip.txt


### PR DESCRIPTION
**Description:** 

When creating a new GitHub release for a recently merged PR (0.6.2), the `pypi-publish.yml` GitHub Action workflow [failed](https://github.com/edx/getsmarter-api-clients/actions/runs/14861195085) due to the following:

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/0d49d25d-ba75-4ae6-81d6-e8b7b076407c" />

The release workflow currently attempts to use the Ubuntu 20.04 runner, which was removed on 2025-04-15. Switching to `ubuntu-latest` aligns the workflow file with other PyPi packages ([example](https://github.com/openedx/edx-enterprise-subsidy-client/blob/17f3758e05d99c23213e60320ea8ddcd9cdf757d/.github/workflows/pypi-publish.yml#L10)).

The current GitHub release/tags for 0.6.2 will be deleted and re-created once this PR merges to re-try its release.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
