### PR TITLE
fix: ensure logging payload allocation in create_enterprise_allocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Unreleased
 [0.6.3]
 ~~~~~~~
 * Logs the allocation payload sent to GEAG within the ``create_enterprise_allocation`` method.
+* Ensures the logging of the allocation payload in both ``create_allocation`` and ``create_enterprise_allocation`` methods
+  only includes specified non-PII fields.
 
 [0.6.2]
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,14 @@ Unreleased
 ~~~~~~~~~~
 * Nothing unreleased
 
+[0.6.3]
+~~~~~~~
+* Logs the allocation payload sent to GEAG within the ``create_enterprise_allocation`` method.
+
 [0.6.2]
 ~~~~~~~
 * Logs the allocation payload sent to GEAG within the ``create_allocation`` method.
+* Upgrades requirements.
 
 [0.6.1]
 ~~~~~~~

--- a/getsmarter_api_clients/__init__.py
+++ b/getsmarter_api_clients/__init__.py
@@ -2,4 +2,4 @@
 Clients to interact with GetSmarter APIs.
 """
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -30,6 +30,25 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         response.raise_for_status()
         return response.json()
 
+    def _get_allocation_payload_for_logging(self, allocation_payload, fields_to_log=None):
+        """
+        Get the allocation payload for logging.
+
+        The payload for logging should only include the fields
+        specified in fields_to_log.
+
+        :param allocation_payload: The allocation payload to log.
+        :param fields_to_log: List of fields to include in the log.
+
+        :return: A dictionary containing only the specified fields.
+        """
+        if not fields_to_log:
+            fields_to_log = []
+        return {
+            field: allocation_payload.get(field)
+            for field in fields_to_log
+        }
+
     def create_allocation(
         self,
         payment_reference,
@@ -133,9 +152,16 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         payload = {k: v for k, v in payload.items() if v is not None}
 
         # log the payload
+        payload_for_logging = self._get_allocation_payload_for_logging(
+            allocation_payload=payload,
+            fields_to_log=[
+                'paymentReference',
+                'orderItems',
+            ],
+        )
         payload_message = (
             f'[create_allocation] Attempting allocation for order {payment_reference} '
-            f'with payload: {payload}'
+            f'with payload: {payload_for_logging}'
         )
         logger.info(payload_message)
 
@@ -269,9 +295,18 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         payload = {k: v for k, v in payload.items() if v is not None}
 
         # log the payload
+        payload_for_logging = self._get_allocation_payload_for_logging(
+            allocation_payload=payload,
+            fields_to_log=[
+                'paymentReference',
+                'enterpriseCustomerUuid',
+                'orgId',
+                'orderItems',
+            ],
+        )
         payload_message = (
             f'[create_enterprise_allocation] Attempting allocation for order {payment_reference} '
-            f'with payload: {payload}'
+            f'with payload: {payload_for_logging}'
         )
         logger.info(payload_message)
 

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -134,7 +134,7 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
 
         # log the payload
         payload_message = (
-            f'Attempting allocation for order {payment_reference} '
+            f'[create_allocation] Attempting allocation for order {payment_reference} '
             f'with payload: {payload}'
         )
         logger.info(payload_message)
@@ -267,6 +267,13 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         }
         # remove keys with empty values
         payload = {k: v for k, v in payload.items() if v is not None}
+
+        # log the payload
+        payload_message = (
+            f'[create_enterprise_allocation] Attempting allocation for order {payment_reference} '
+            f'with payload: {payload}'
+        )
+        logger.info(payload_message)
 
         response = self.post(url, json=payload)
         try:

--- a/getsmarter_api_clients/geag.py
+++ b/getsmarter_api_clients/geag.py
@@ -37,10 +37,12 @@ class GetSmarterEnterpriseApiClient(OAuthApiClient):
         The payload for logging should only include the fields
         specified in fields_to_log.
 
-        :param allocation_payload: The allocation payload to log.
-        :param fields_to_log: List of fields to include in the log.
+        Args:
+            allocation_payload: The allocation payload to log.
+            fields_to_log: List of fields to include in the log.
 
-        :return: A dictionary containing only the specified fields.
+        Returns:
+            A dictionary containing only the specified fields.
         """
         if not fields_to_log:
             fields_to_log = []


### PR DESCRIPTION
**Description:** 

The previous PR (https://github.com/edx/getsmarter-api-clients/pull/26) only added the additional logging to `create_allocation`, despite the enterprise-subsidy IDA using `create_enterprise_allocation`.

This PR ensures the logging is included in both methods, with a prefix to distinguish between the two.

**JIRA:** [ENT-10386](https://2u-internal.atlassian.net/browse/ENT-10386)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Create _enterprise_ allocation.
2. Observe logging.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
